### PR TITLE
Fixed init and button detection runtime

### DIFF
--- a/examples/joystick-input/joystick-input.go
+++ b/examples/joystick-input/joystick-input.go
@@ -37,7 +37,7 @@ func run() (err error) {
 			case *sdl.JoyBallEvent:
 				fmt.Println("Joystick", t.Which, "trackball moved by", t.XRel, t.YRel)
 			case *sdl.JoyButtonEvent:
-				if t.Type == sdl.PRESSED {
+				if t.State == sdl.PRESSED {
 					fmt.Println("Joystick", t.Which, "button", t.Button, "pressed")
 				} else {
 					fmt.Println("Joystick", t.Which, "button", t.Button, "released")
@@ -69,7 +69,7 @@ func run() (err error) {
 				fmt.Println("Joystick", t.Which, "hat", t.Hat, "moved to", position, "position")
 			case *sdl.JoyDeviceAddedEvent:
 				// Open joystick for use
-				joysticks[int(t.Which)] = sdl.JoystickOpen(t.Which)
+				joysticks[int(t.Which)] = sdl.JoystickOpen(int(t.Which))
 				if joysticks[int(t.Which)] != nil {
 					fmt.Println("Joystick", t.Which, "connected")
 				}


### PR DESCRIPTION
Fixed some small issues in the joystick example.

The `JoyButtonEvent` handler was checking against `t.Type` when it should have been checking against `t.State`. this caused the script to always state a button was released, even if the event was indicating the button was pressed.

There appears to be a missing int cast on the `JoyDeviceAddedEvent`, which resulted in compile errors. 
```
./example.go:73:49: cannot use t.Which (type sdl.JoystickID) as type int in argument to sdl.JoystickOpen

```